### PR TITLE
fix: get full private_bls_key

### DIFF
--- a/docker/eigenlayer/get_bls_key.sh
+++ b/docker/eigenlayer/get_bls_key.sh
@@ -20,9 +20,9 @@ tmux send-keys -t export_key "y" C-m
 sleep 1
 tmux send-keys -t export_key "$PASSWORD" C-m
 
-# Capture the output
+# Capture the output and format it
 sleep 1
-tmux capture-pane -t export_key -p
+tmux capture-pane -t export_key -S - -E - -p | grep -A1 "Private key:" | tr -d 'Private key: \n'
 
 # Kill the session
 tmux kill-session -t export_key

--- a/docker/eigenlayer/register.sh
+++ b/docker/eigenlayer/register.sh
@@ -74,7 +74,8 @@ if [ $? -ne 0 ]; then
     echo "Error: Failed to create bls key for $new_account"
     exit 1
 fi
-private_bls_key=$(./get_bls_key.sh $password $new_account  | grep "Private key:" | awk '{print $3}')
+private_bls_key=$(./get_bls_key.sh $password $new_account)
+echo $private_bls_key
 if [ $? -ne 0 ]; then
     echo "Error: Failed to get bls key for $new_account"
     exit 1


### PR DESCRIPTION
fixed the tmux call to capture the full private key, moved processing from register.sh to get_bls_key.sh