### PR TITLE
Fix: Update Docker image references to use dev tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,12 +37,22 @@ jobs:
         run: |
           echo "Something has changed in eigenlayer directory, building image..."
           cd docker/eigenlayer
-          docker build -t opacitylabs/eigenlayer:k8s-latest -f Dockerfile.eigenlayer .
-          docker push opacitylabs/eigenlayer:k8s-latest
+          if [ "${{ github.ref_name }}" == "dev" ]; then
+            docker build -t opacitylabs/eigenlayer-local:dev -f Dockerfile.eigenlayer .
+            docker push opacitylabs/eigenlayer-local:dev
+          elif [ "${{ github.ref_name }}" == "k8s" ]; then
+            docker build -t opacitylabs/eigenlayer:k8s-latest -f Dockerfile.eigenlayer .
+            docker push opacitylabs/eigenlayer:k8s-latest
+          fi
 
       - name: Build and Push Ethereum Image
         if: steps.changes.outputs.ethereum == 'true'
         run: |
           echo "Ethereum Dockerfile changed, building image..."
-          docker build -t opacitylabs/ethereum:dev-latest -f docker/ethereum/Dockerfile.ethereum .
-          docker push opacitylabs/ethereum:dev-latest
+          if [ "${{ github.ref_name }}" == "dev" ]; then
+            docker build -t opacitylabs/ethereum-local:dev -f docker/ethereum/Dockerfile.ethereum docker/ethereum
+            docker push opacitylabs/ethereum-local:dev
+          elif [ "${{ github.ref_name }}" == "k8s" ]; then
+            docker build -t opacitylabs/ethereum:k8s-latest -f docker/ethereum/Dockerfile.ethereum docker/ethereum
+            docker push opacitylabs/ethereum:k8s-latest
+          fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ethereum:
-    image: opacitylabs/ethereum-local
+    image: opacitylabs/ethereum-local:dev
     pull_policy: always
     # platform: linux/amd64
     # build:
@@ -12,7 +12,7 @@ services:
       - "8545:8545"
   
   eigenlayer:
-    image: opacitylabs/eigenlayer-local
+    image: opacitylabs/eigenlayer-local:dev
     pull_policy: always
     # platform: linux/amd64
     # build:


### PR DESCRIPTION
## Summary
- Updates Docker image references to use `dev` tag for consistency
- Fixes issue #12 regarding updating references from breadchaincoop/eigenlayer-bls-local to dev
- Updates GitHub workflow to properly tag images based on branch

## Changes Made
1. Updated `docker-compose.yml`:
   - Changed `opacitylabs/eigenlayer-local` to `opacitylabs/eigenlayer-local:dev`
   - Changed `opacitylabs/ethereum-local` to `opacitylabs/ethereum-local:dev`

2. Updated `.github/workflows/docker-build.yml`:
   - Added conditional logic to tag images based on branch name
   - Dev branch builds push to `:dev` tags
   - K8s branch builds push to `:k8s-latest` tags

## Test Plan
- [ ] Verify docker-compose pulls the correct dev-tagged images
- [ ] Confirm GitHub Actions workflow builds and pushes correct tags on dev branch
- [ ] Ensure backward compatibility for k8s branch deployments

Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)